### PR TITLE
Add an option to show empty cells.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Disable Basic Table's JS resize. The table won't engage in responsive mode unles
 
 When the library is initialize create a div wrapper around the table with class .bt-wrapper. This wrapper will toggle an active class when the table mode changes.
 
+### showEmptyCells
+
+`boolean` `default: false`
+
+When true, empty cells will be shown.
+
 ## Methods
 
 ### start

--- a/jquery.basictable.js
+++ b/jquery.basictable.js
@@ -57,7 +57,7 @@
       $row.children().each(function() {
         var $cell = $(this);
 
-        if ($cell.html() === '' || $cell.html() === '&nbsp;') {
+        if (($cell.html() === '' || $cell.html() === '&nbsp;') && (!data.showEmptyCells)) {
           $cell.addClass('bt-hide');
         }
         else {
@@ -180,7 +180,8 @@
         contentWrap: settings.contentWrap,
         forceResponsive: settings.forceResponsive,
         noResize: settings.noResize,
-        tableWrap: settings.tableWrap
+        tableWrap: settings.tableWrap,
+        showEmptyCells: settings.showEmptyCells
       };
 
       // Initiate
@@ -203,6 +204,7 @@
     contentWrap: true,
     forceResponsive: true,
     noResize: false,
-    tableWrap: false
+    tableWrap: false,
+    showEmptyCells: false
   };
 })(jQuery);


### PR DESCRIPTION
Had a situation where display of the empty cells was needed. 

A 'showEmptyCells' setting was added, which will show these empty cells. The default setting is false so that it is backward compatible with earlier versions. 
